### PR TITLE
update handler to new filename conventions for matching data

### DIFF
--- a/src/netex-convertor/data/s3.ts
+++ b/src/netex-convertor/data/s3.ts
@@ -33,7 +33,6 @@ export const fetchDataFromS3 = async (event: S3Event): Promise<any> => {
                     .promise()
             ).Body?.toString('utf-8') ?? '';
         const dataAsJson: JSON = JSON.parse(dataAsString);
-        console.log('data as json', dataAsJson);
         return dataAsJson;
     } catch (err) {
         throw new Error(`Error in retrieving data. ${err.stack}`);

--- a/src/netex-convertor/data/s3.ts
+++ b/src/netex-convertor/data/s3.ts
@@ -33,6 +33,7 @@ export const fetchDataFromS3 = async (event: S3Event): Promise<any> => {
                     .promise()
             ).Body?.toString('utf-8') ?? '';
         const dataAsJson: JSON = JSON.parse(dataAsString);
+        console.log('data as json', dataAsJson);
         return dataAsJson;
     } catch (err) {
         throw new Error(`Error in retrieving data. ${err.stack}`);

--- a/src/netex-convertor/handler.test.ts
+++ b/src/netex-convertor/handler.test.ts
@@ -1,5 +1,5 @@
 import { S3Event } from 'aws-lambda';
-import { netexConvertorHandler } from './handler';
+import { netexConvertorHandler, generateFileName } from './handler';
 import {
     singleTicket,
     periodGeoZoneTicket,
@@ -111,5 +111,12 @@ describe('netexConvertorHandler', () => {
         await netexConvertorHandler(event);
         const generatedNetex: string = mockUploadNetexToS3Spy.mock.calls[0][0];
         expect(generatedNetex.includes('undefined')).toBeFalsy();
+    });
+
+    it('should generate the correct filename', () => {
+        const mockDate = Date.now();
+        jest.spyOn(global.Date, 'now').mockImplementation(() => mockDate);
+        const fileName = generateFileName('DCCL', 'single', 'abcdef123');
+        expect(fileName).toEqual(`DCCL/single/abcdef123-${mockDate}.xml`);
     });
 });

--- a/src/netex-convertor/handler.ts
+++ b/src/netex-convertor/handler.ts
@@ -18,10 +18,13 @@ const uploadToS3 = async (netex: string, fileName: string): Promise<void> => {
     );
 };
 
+const generateFileName = (nocCode: string, type: string, uuid: string) =>
+    `${nocCode}/${type}/${uuid}-${Date.now()}.xml`;
+
 export const netexConvertorHandler = async (event: S3Event): Promise<void> => {
     try {
         const s3Data = await s3.fetchDataFromS3(event);
-        const { type, uuid } = s3Data;
+        const { type, uuid, nocCode } = s3Data;
 
         console.info(`NeTEx generation starting for type: ${type}...`);
 
@@ -32,9 +35,7 @@ export const netexConvertorHandler = async (event: S3Event): Promise<void> => {
             const netexGen = pointToPointTicketNetexGenerator(matchingData, operatorData);
             const generatedNetex = await netexGen.generate();
 
-            const { nocCode } = matchingData;
-
-            const fileName = `${nocCode}/${type}/${uuid}-${Date.now()}.xml`;
+            const fileName = generateFileName(nocCode, type, uuid);
 
             await uploadToS3(generatedNetex, fileName);
         } else if (type === 'periodGeoZone' || type === 'periodMultipleServices' || type === 'flatFare') {
@@ -43,17 +44,7 @@ export const netexConvertorHandler = async (event: S3Event): Promise<void> => {
             const netexGen = periodTicketNetexGenerator(userPeriodTicket, operatorData);
             const generatedNetex = await netexGen.generate();
 
-            let productName;
-
-            if (userPeriodTicket.products.length > 1) {
-                productName = `${userPeriodTicket.products.length}-products`;
-            } else {
-                productName = userPeriodTicket.products[0].productName;
-            }
-            const fileName = `${userPeriodTicket.operatorName.replace(
-                /\/|\s/g,
-                '_',
-            )}_${productName}_${new Date().toISOString()}.xml`;
+            const fileName = generateFileName(nocCode, type, uuid);
 
             await uploadToS3(generatedNetex, fileName);
         } else {

--- a/src/netex-convertor/handler.ts
+++ b/src/netex-convertor/handler.ts
@@ -21,7 +21,7 @@ const uploadToS3 = async (netex: string, fileName: string): Promise<void> => {
 export const netexConvertorHandler = async (event: S3Event): Promise<void> => {
     try {
         const s3Data = await s3.fetchDataFromS3(event);
-        const { type } = s3Data;
+        const { type, uuid } = s3Data;
 
         console.info(`NeTEx generation starting for type: ${type}...`);
 
@@ -32,9 +32,9 @@ export const netexConvertorHandler = async (event: S3Event): Promise<void> => {
             const netexGen = pointToPointTicketNetexGenerator(matchingData, operatorData);
             const generatedNetex = await netexGen.generate();
 
-            const fileName = `${matchingData.operatorShortName.replace(/\/|\s/g, '_')}_${
-                matchingData.lineName
-            }_${new Date().toISOString()}.xml`;
+            const { nocCode } = matchingData;
+
+            const fileName = `${nocCode}/${type}/${uuid}-${Date.now()}.xml`;
 
             await uploadToS3(generatedNetex, fileName);
         } else if (type === 'periodGeoZone' || type === 'periodMultipleServices' || type === 'flatFare') {

--- a/src/netex-convertor/handler.ts
+++ b/src/netex-convertor/handler.ts
@@ -18,7 +18,7 @@ const uploadToS3 = async (netex: string, fileName: string): Promise<void> => {
     );
 };
 
-const generateFileName = (nocCode: string, type: string, uuid: string): string =>
+export const generateFileName = (nocCode: string, type: string, uuid: string): string =>
     `${nocCode}/${type}/${uuid}-${Date.now()}.xml`;
 
 export const netexConvertorHandler = async (event: S3Event): Promise<void> => {

--- a/src/netex-convertor/handler.ts
+++ b/src/netex-convertor/handler.ts
@@ -18,7 +18,7 @@ const uploadToS3 = async (netex: string, fileName: string): Promise<void> => {
     );
 };
 
-const generateFileName = (nocCode: string, type: string, uuid: string) =>
+const generateFileName = (nocCode: string, type: string, uuid: string): string =>
     `${nocCode}/${type}/${uuid}-${Date.now()}.xml`;
 
 export const netexConvertorHandler = async (event: S3Event): Promise<void> => {


### PR DESCRIPTION
# Description

As part of https://infinityworks.atlassian.net/browse/TFN-539 we were required to update the netex handler to allow for the new file name formats

# Testing instructions

- Check this branch out
- Go to fdbt-dev pr https://github.com/fares-data-build-tool/fdbt-dev/pull/10 and run the following commands
- Run make generate-single - this should generate the xml in the correct format
- make generate-return-service
- make generate-return-service-circular

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
