### PR TITLE
fix: Make id's unique for sales offer package elements

### DIFF
--- a/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
+++ b/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
@@ -409,11 +409,11 @@ export const getSalesOfferPackageList = (
             };
 
             const buildSalesOfferPackageElements = (): SalesOfferPackageElement[] => {
-                const salesOfferPackageElements = salesOfferPackage.ticketFormats.map(ticketFormat => {
+                const salesOfferPackageElements = salesOfferPackage.ticketFormats.map((ticketFormat, index) => {
                     return {
                         id: `Trip@${ticketUserConcat}-${product.productName}-${salesOfferPackage.name}@${ticketFormat}`,
                         version: '1.0',
-                        order: '3',
+                        order: `${index + 1}`,
                         TypeOfTravelDocumentRef: {
                             version: 'fxc:v1.0',
                             ref: `fxc:${ticketFormat}`,


### PR DESCRIPTION
# Description

-   Sales offer package elements ID's were not unqiue if the ticket formats matched. Changed it so the order takes the index and adds one, making them unique.

# Testing instructions

-   Create netex and validate.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
