### PR TITLE
Added new option for productValidity

### DIFF
--- a/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
+++ b/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
@@ -757,7 +757,12 @@ const getConditionsElement = (product: ProductDetails): NetexObject => {
                 version: '1.0',
                 id: `op:Trip@${product.productName}@back@frequency`,
                 UsageTrigger: { $t: 'purchase' },
-                UsageEnd: { $t: product.productValidity === 'endOfCalendarDay' ? 'endOfFareDay' : 'standardDuration' },
+                UsageEnd: {
+                    $t:
+                        product.productValidity === 'endOfCalendarDay' || product.productValidity === 'endOfServiceDay'
+                            ? 'endOfFareDay'
+                            : 'standardDuration',
+                },
                 ActivationMeans: { $t: 'noneRequired' },
             },
         };


### PR DESCRIPTION
# Description

-   To allow the netex to act differently depending on new productValidity option of 'endOfServiceDay',

# Testing instructions

-   Assert netex all still validates.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x ] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
