### PR TITLE
fix: Added lineId inclusion for logged in operators' services

### DIFF
--- a/src/netex-convertor/period-tickets/periodTicketNetexHelpers.test.ts
+++ b/src/netex-convertor/period-tickets/periodTicketNetexHelpers.test.ts
@@ -144,7 +144,7 @@ describe('periodTicketNetexHelpers', () => {
                 Description: { $t: expect.any(String) },
                 Url: expect.objectContaining({ $t: expect.any(String) }),
                 PublicCode: expect.objectContaining({ $t: expect.any(String) }),
-                PrivateCode: expect.objectContaining({ type: 'noc', $t: expect.any(String) }),
+                PrivateCode: expect.objectContaining({ type: 'txc:Line@id', $t: expect.any(String) }),
                 OperatorRef: { version: '1.0', ref: expect.stringContaining('noc:') },
                 LineType: { $t: 'local' },
             };

--- a/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
+++ b/src/netex-convertor/period-tickets/periodTicketNetexHelpers.ts
@@ -128,7 +128,12 @@ export const getLinesList = (
                   Description: { $t: service.serviceDescription },
                   Url: { $t: website },
                   PublicCode: { $t: service.lineName },
-                  PrivateCode: { type: 'noc', $t: `${userPeriodTicket.nocCode}_${service.lineName}` },
+                  PrivateCode: service.lineId
+                      ? {
+                            type: 'txc:Line@id',
+                            $t: service.lineId,
+                        }
+                      : {},
                   OperatorRef: {
                       version: '1.0',
                       ref: `noc:${replaceIWBusCoNocCode(userPeriodTicket.nocCode)}`,


### PR DESCRIPTION
# Description

-   Logged in operators' lineId's were not being included in their lines list when their Netex was being created, though it was happening for their additonal operators services, if there were any.

# Testing instructions

-   Create netex and observe it is now present. Unit test also proves this.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
